### PR TITLE
pull the current URL from the active window

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.6</string>
+	<string>2.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>138</string>
+	<string>139</string>
 	<key>QSActions</key>
 	<dict>
 		<key>QSSafariAddToReadingListAction</key>

--- a/QSSafariPlugin.m
+++ b/QSSafariPlugin.m
@@ -60,19 +60,23 @@
 {
 	[self createSafariAndLaunch:NO];
 	if ([Safari isRunning]) {
-		SafariTab *currentTab = [[[Safari windows] objectAtIndex:0] currentTab];
-		NSString *url = [currentTab URL];
-		NSString *title = [currentTab name];
-		if (url) {
-			if ([[proxy identifier] isEqualToString:@"QSSafariFrontPageProxy"]) {
-				return [QSObject URLObjectWithURL:url title:title];
-			}
-			if ([[proxy identifier] isEqualToString:@"QSSafariSearchCurrentSite"]) {
-				NSURL *currentURL = [NSURL URLWithString:url];
-				NSString *searchShortcut = [NSString stringWithFormat:@"http://www.google.com/search?q=*** site:%@", [currentURL host]];
-				return [QSObject URLObjectWithURL:searchShortcut title:nil];
-			}
-		}
+        NSPredicate *activeWindowFilter = [NSPredicate predicateWithFormat:@"visible == YES"];
+        NSArray *active = [[Safari windows] filteredArrayUsingPredicate:activeWindowFilter];
+        if ([active count]) {
+            SafariTab *currentTab = [[active objectAtIndex:0] currentTab];
+            NSString *url = [currentTab URL];
+            NSString *title = [currentTab name];
+            if (url) {
+                if ([[proxy identifier] isEqualToString:@"QSSafariFrontPageProxy"]) {
+                    return [QSObject URLObjectWithURL:url title:title];
+                }
+                if ([[proxy identifier] isEqualToString:@"QSSafariSearchCurrentSite"]) {
+                    NSURL *currentURL = [NSURL URLWithString:url];
+                    NSString *searchShortcut = [NSString stringWithFormat:@"http://www.google.com/search?q=*** site:%@", [currentURL host]];
+                    return [QSObject URLObjectWithURL:searchShortcut title:nil];
+                }
+            }
+        }
 	}
 	return nil;
 }


### PR DESCRIPTION
I’ve been using multiple windows more lately and finally figured out that I hard-coded Current Web Page to pull from the first window. In my defense, there was no obvious way to get the active window. (“visible”? Come on.)

Most of the changes are just to indent things inside the test for at least one active window.